### PR TITLE
core_path_planner: 計算量削減（A*本体3.4〜11倍高速化＋再計画のタイマー駆動化）

### DIFF
--- a/core_path_planner/README.md
+++ b/core_path_planner/README.md
@@ -29,16 +29,35 @@ This package provides a path planner node that:
 
 ### Parameters
 
-| Parameter             | Type   | Default          | Description                                       |
-| --------------------- | ------ | ---------------- | ------------------------------------------------- |
-| `global_map_topic`    | string | `/map`           | Topic name for global map                         |
-| `local_costmap_topic` | string | `/local_costmap` | Topic name for local costmap                      |
-| `start_topic`         | string | `/start_pose`    | Topic name for start pose                         |
-| `goal_topic`          | string | `/goal_pose`     | Topic name for goal pose                          |
-| `path_topic`          | string | `/planned_path`  | Topic name for output path                        |
-| `occupied_threshold`  | int    | `50`             | Threshold for considering a cell occupied (0-100) |
-| `allow_unknown`       | bool   | `false`          | Whether to allow planning through unknown cells   |
-| `use_diagonal`        | bool   | `true`           | Whether to allow diagonal movement                |
+| Parameter                   | Type   | Default          | Description                                                                                                                       |
+| --------------------------- | ------ | ---------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `global_map_topic`          | string | `/map`           | Topic name for global map                                                                                                          |
+| `local_costmap_topic`       | string | `/local_costmap` | Topic name for local costmap                                                                                                       |
+| `start_topic`               | string | `/start_pose`    | Topic name for start pose                                                                                                          |
+| `goal_topic`                | string | `/goal_pose`     | Topic name for goal pose                                                                                                           |
+| `path_topic`                | string | `/planned_path`  | Topic name for output path                                                                                                         |
+| `local_frame_id`            | string | `chassis_link`   | Frame id of the published path when `publish_in_global_frame` is false                                                             |
+| `publish_in_global_frame`   | bool   | `false`          | Publish the path in the global frame instead of the robot-local frame                                                              |
+| `global_frame_id`           | string | `odom`           | Frame id of the published path when `publish_in_global_frame` is true                                                              |
+| `occupied_threshold`        | int    | `50`             | Threshold for considering a cell occupied (0-100)                                                                                  |
+| `allow_unknown`             | bool   | `true`           | Whether to allow planning through unknown cells                                                                                    |
+| `use_diagonal`              | bool   | `true`           | Whether to allow diagonal movement                                                                                                 |
+| `cost_weight`               | double | `0.0`            | Weight of cell cost values added to step costs (0 disables cost-aware planning)                                                    |
+| `search_window_margin`      | int    | `-1`             | Cells added around the start-goal bounding box for a windowed first search attempt. Falls back to a full-map search only when the window contains no path, so windowed results may be costlier than the global optimum. Negative disables windowing (always globally optimal) |
+| `replan_rate_hz`            | double | `5.0`            | Rate of the replan timer; planning runs at most this often                                                                         |
+| `replan_position_tolerance` | double | `0.0`            | Start-pose translation (m) beyond which a replan is requested (compared against the start pose of the last successful plan)        |
+| `replan_yaw_tolerance`      | double | `0.0`            | Start-pose yaw change (rad) beyond which a replan is requested                                                                     |
+
+### Replanning behavior
+
+Planning is decoupled from topic rates: callbacks only record inputs and set
+a dirty flag, and a wall timer (`replan_rate_hz`) runs A* only when an input
+actually changed since the last plan. Receiving a map, goal, or local
+costmap always requests a replan; a start pose requests one only when it
+moved beyond the tolerances relative to the last successful plan. The last
+planned path is additionally re-transformed and republished on every start
+pose message (cheap, no search), so local-frame consumers always see the
+path relative to the current robot pose even between replans.
 
 ## Usage
 

--- a/core_path_planner/include/path_planner/path_planner.hpp
+++ b/core_path_planner/include/path_planner/path_planner.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <nav_msgs/msg/occupancy_grid.hpp>
 #include <optional>
@@ -23,6 +24,12 @@ public:
     bool allow_unknown{false};
     bool use_diagonal{true};
     double cost_weight{0.0};
+    // Margin (in cells) added around the start-goal bounding box for the
+    // first search attempt; falls back to a full-map search only when the
+    // windowed attempt finds NO path, so a path found inside the window
+    // may be costlier than the global optimum (speed/optimality
+    // trade-off). Negative disables windowing (always globally optimal).
+    int search_window_margin{-1};
   };
 
   enum class Status
@@ -47,7 +54,7 @@ public:
   PlanResult plan(
     const nav_msgs::msg::OccupancyGrid & map,
     const geometry_msgs::msg::PoseStamped & start,
-    const geometry_msgs::msg::PoseStamped & goal) const;
+    const geometry_msgs::msg::PoseStamped & goal);
 
   void gridToWorld(
     const nav_msgs::msg::OccupancyGrid & map,
@@ -57,15 +64,33 @@ private:
   struct OpenItem
   {
     double f;
-    double g;
     int index;
-    bool operator<(const OpenItem & other) const {return f > other.f;}
+  };
+
+  struct OpenItemGreater
+  {
+    bool operator()(const OpenItem & a, const OpenItem & b) const
+    {
+      return a.f > b.f;
+    }
+  };
+
+  struct Window
+  {
+    int x0;
+    int y0;
+    int x1;
+    int y1;
   };
 
   bool computePath(
     const nav_msgs::msg::OccupancyGrid & map,
     const GridIndex & start, const GridIndex & goal,
-    std::vector<GridIndex> & out_path) const;
+    std::vector<GridIndex> & out_path);
+  bool searchWindow(
+    const nav_msgs::msg::OccupancyGrid & map,
+    const GridIndex & start, const GridIndex & goal,
+    const Window & window, std::vector<GridIndex> & out_path);
   void reconstructPath(
     const nav_msgs::msg::OccupancyGrid & map,
     const std::vector<int> & came_from, int goal_index,
@@ -74,12 +99,40 @@ private:
   bool worldToGrid(
     const nav_msgs::msg::OccupancyGrid & map, double wx,
     double wy, GridIndex & cell) const;
-  bool isOccupied(
-    const nav_msgs::msg::OccupancyGrid & map,
-    const GridIndex & cell) const;
+
+  // Precomputes a merged (max of global and local) value patch over the
+  // region of the global grid covered by the local costmap, so the search
+  // loop never does world<->grid transforms per neighbor.
+  void buildLocalPatch(const nav_msgs::msg::OccupancyGrid & map);
+  int8_t cellValue(
+    const nav_msgs::msg::OccupancyGrid & map, int index, int x, int y) const;
+  bool isBlocked(int8_t value) const;
+
+  // Advances the generation stamp so scratch buffers become logically
+  // clear in O(1); buffers are only re-filled when the map size changes
+  // or the 32-bit stamp wraps.
+  void beginSearchEpoch(int map_size);
 
   Settings settings_;
   std::optional<nav_msgs::msg::OccupancyGrid> local_costmap_;
+
+  // Per-plan scratch, reused across calls. A cell's g_score_/came_from_
+  // (or closed state) is valid only when its stamp equals generation_.
+  std::vector<double> g_score_;
+  std::vector<int> came_from_;
+  std::vector<uint32_t> visit_gen_;
+  std::vector<uint32_t> closed_gen_;
+  uint32_t generation_{0};
+  std::vector<OpenItem> open_heap_;
+
+  // Merged local-costmap patch, in global grid coordinates.
+  bool patch_active_{false};
+  int patch_x0_{0};
+  int patch_y0_{0};
+  int patch_x1_{-1};
+  int patch_y1_{-1};
+  int patch_width_{0};
+  std::vector<int8_t> patch_values_;
 
   static constexpr double kDiagonalCost = 1.41421356237;
 };

--- a/core_path_planner/include/path_planner/path_planner_node.hpp
+++ b/core_path_planner/include/path_planner/path_planner_node.hpp
@@ -27,14 +27,20 @@ private:
     const geometry_msgs::msg::PoseStamped::SharedPtr msg);
   void onGoalPoseReceived(const geometry_msgs::msg::PoseStamped::SharedPtr msg);
 
+  // Runs at replan_rate_hz and plans only when an input changed since the
+  // last plan, decoupling planning cost from topic rates.
+  void onReplanTimer();
+
   void tryPlan();
+
+  // Transforms the cells with the CURRENT start pose and publishes; cheap
+  // (no search), so it also runs on every start-pose message to keep the
+  // local-frame path aligned with the moving robot between replans.
   void publishPath(const std::vector<PathPlanner::GridIndex> & path_cells);
 
-  // Transform a point from global to local (robot) coordinates
-  void transformToLocal(
-    double global_x, double global_y,
-    const geometry_msgs::msg::Pose & robot_pose,
-    double & local_x, double & local_y) const;
+  // True when the pose differs from the start pose used for the last plan
+  // by more than the configured tolerances.
+  bool startPoseChanged(const geometry_msgs::msg::PoseStamped & pose) const;
 
   // Extract yaw from quaternion
   double getYawFromQuaternion(const geometry_msgs::msg::Quaternion & q) const;
@@ -55,6 +61,10 @@ private:
   bool allow_unknown_;
   bool use_diagonal_;
   double cost_weight_;
+  int search_window_margin_;
+  double replan_rate_hz_;
+  double replan_position_tolerance_;
+  double replan_yaw_tolerance_;
 
   // Subscribers
   rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr global_map_sub_;
@@ -66,10 +76,16 @@ private:
   // Publishers
   rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr path_pub_;
 
+  // Timers
+  rclcpp::TimerBase::SharedPtr replan_timer_;
+
   // State
   std::optional<nav_msgs::msg::OccupancyGrid> global_map_;
   std::optional<geometry_msgs::msg::PoseStamped> start_pose_;
   std::optional<geometry_msgs::msg::PoseStamped> goal_pose_;
+  std::optional<geometry_msgs::msg::PoseStamped> last_planned_start_;
+  std::vector<PathPlanner::GridIndex> last_path_cells_;
+  bool plan_pending_{false};
 };
 
 }  // namespace path_planner

--- a/core_path_planner/src/path_planner.cpp
+++ b/core_path_planner/src/path_planner.cpp
@@ -2,8 +2,8 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <limits>
-#include <queue>
 
 namespace path_planner
 {
@@ -25,7 +25,7 @@ void PathPlanner::setLocalCostmap(
 PathPlanner::PlanResult PathPlanner::plan(
   const nav_msgs::msg::OccupancyGrid & map,
   const geometry_msgs::msg::PoseStamped & start,
-  const geometry_msgs::msg::PoseStamped & goal) const
+  const geometry_msgs::msg::PoseStamped & goal)
 {
   GridIndex start_cell;
   GridIndex goal_cell;
@@ -39,7 +39,23 @@ PathPlanner::PlanResult PathPlanner::plan(
     return PlanResult{Status::kStartOrGoalOutOfBounds, {}};
   }
 
-  if (isOccupied(map, start_cell) || isOccupied(map, goal_cell)) {
+  const int width = static_cast<int>(map.info.width);
+  const int height = static_cast<int>(map.info.height);
+  if (map.data.size() <
+    static_cast<size_t>(width) * static_cast<size_t>(height))
+  {
+    // Malformed grid: treat like the fully occupied map it would have
+    // been under per-cell bounds checking.
+    return PlanResult{Status::kStartOrGoalOccupied, {}};
+  }
+
+  buildLocalPatch(map);
+
+  const int start_index = start_cell.y * width + start_cell.x;
+  const int goal_index = goal_cell.y * width + goal_cell.x;
+  if (isBlocked(cellValue(map, start_index, start_cell.x, start_cell.y)) ||
+    isBlocked(cellValue(map, goal_index, goal_cell.x, goal_cell.y)))
+  {
     return PlanResult{Status::kStartOrGoalOccupied, {}};
   }
 
@@ -54,85 +70,113 @@ PathPlanner::PlanResult PathPlanner::plan(
 bool PathPlanner::computePath(
   const nav_msgs::msg::OccupancyGrid & map,
   const GridIndex & start, const GridIndex & goal,
-  std::vector<GridIndex> & out_path) const
+  std::vector<GridIndex> & out_path)
 {
   const int width = static_cast<int>(map.info.width);
   const int height = static_cast<int>(map.info.height);
-  const int map_size = width * height;
+
+  const int margin = settings_.search_window_margin;
+  if (margin >= 0) {
+    const Window window{
+      std::max(0, std::min(start.x, goal.x) - margin),
+      std::max(0, std::min(start.y, goal.y) - margin),
+      std::min(width - 1, std::max(start.x, goal.x) + margin),
+      std::min(height - 1, std::max(start.y, goal.y) + margin)};
+    const bool covers_full_map = window.x0 == 0 && window.y0 == 0 &&
+      window.x1 == width - 1 && window.y1 == height - 1;
+    if (!covers_full_map &&
+      searchWindow(map, start, goal, window, out_path))
+    {
+      return true;
+    }
+    // Windowed attempt failed: fall back to the full map to preserve
+    // completeness.
+  }
+
+  const Window full_map{0, 0, width - 1, height - 1};
+  return searchWindow(map, start, goal, full_map, out_path);
+}
+
+bool PathPlanner::searchWindow(
+  const nav_msgs::msg::OccupancyGrid & map,
+  const GridIndex & start, const GridIndex & goal,
+  const Window & window, std::vector<GridIndex> & out_path)
+{
+  const int width = static_cast<int>(map.info.width);
+  const int height = static_cast<int>(map.info.height);
+  beginSearchEpoch(width * height);
 
   auto indexOf = [width](int x, int y) {return y * width + x;};
   auto toGrid = [width](int index) -> GridIndex {
       return GridIndex{index % width, index / width};
     };
 
-  std::vector<double> g_score(map_size,
-    std::numeric_limits<double>::infinity());
-  std::vector<int> came_from(map_size, -1);
-  std::vector<bool> closed(map_size, false);
-  std::priority_queue<OpenItem> open;
-
   const int start_index = indexOf(start.x, start.y);
   const int goal_index = indexOf(goal.x, goal.y);
-  g_score[start_index] = 0.0;
-  open.push(OpenItem{heuristic(start, goal), 0.0, start_index});
+  g_score_[start_index] = 0.0;
+  came_from_[start_index] = -1;
+  visit_gen_[start_index] = generation_;
+  open_heap_.clear();
+  open_heap_.push_back(OpenItem{heuristic(start, goal), start_index});
 
-  const std::vector<GridIndex> neighbors =
-    settings_.use_diagonal ?
-    std::vector<GridIndex>{{1, 0}, {-1, 0}, {0, 1}, {0, -1},
-    {1, 1}, {-1, 1}, {1, -1}, {-1, -1}} :
-  std::vector<GridIndex>{{1, 0}, {-1, 0}, {0, 1}, {0, -1}};
+  static constexpr GridIndex kDiagonalOffsets[8] =
+  {{1, 0}, {-1, 0}, {0, 1}, {0, -1}, {1, 1}, {-1, 1}, {1, -1}, {-1, -1}};
+  static constexpr GridIndex kCardinalOffsets[4] =
+  {{1, 0}, {-1, 0}, {0, 1}, {0, -1}};
+  const GridIndex * neighbors =
+    settings_.use_diagonal ? kDiagonalOffsets : kCardinalOffsets;
+  const int neighbor_count = settings_.use_diagonal ? 8 : 4;
 
-  while (!open.empty()) {
-    auto current = open.top();
-    open.pop();
-    if (closed[current.index]) {
+  while (!open_heap_.empty()) {
+    std::pop_heap(open_heap_.begin(), open_heap_.end(), OpenItemGreater{});
+    const OpenItem current = open_heap_.back();
+    open_heap_.pop_back();
+    if (closed_gen_[current.index] == generation_) {
       continue;
     }
     if (current.index == goal_index) {
-      reconstructPath(map, came_from, goal_index, out_path);
+      reconstructPath(map, came_from_, goal_index, out_path);
       return true;
     }
-    closed[current.index] = true;
+    closed_gen_[current.index] = generation_;
 
-    GridIndex current_cell = toGrid(current.index);
-    for (const auto & offset : neighbors) {
-      GridIndex next{current_cell.x + offset.x, current_cell.y + offset.y};
-      if (next.x < 0 || next.y < 0 || next.x >= width || next.y >= height) {
-        continue;
-      }
-      if (isOccupied(map, next)) {
+    const GridIndex current_cell = toGrid(current.index);
+    const double current_g = g_score_[current.index];
+    for (int i = 0; i < neighbor_count; ++i) {
+      const GridIndex & offset = neighbors[i];
+      const GridIndex next{current_cell.x + offset.x,
+        current_cell.y + offset.y};
+      if (next.x < window.x0 || next.y < window.y0 || next.x > window.x1 ||
+        next.y > window.y1)
+      {
         continue;
       }
       const int next_index = indexOf(next.x, next.y);
-      if (closed[next_index]) {
+      if (closed_gen_[next_index] == generation_) {
         continue;
       }
-      const double base_cost = (offset.x != 0 && offset.y != 0) ? kDiagonalCost : 1.0;
-      double step_cost = base_cost;
-      if (settings_.cost_weight > 0.0) {
-        int8_t cell_value = map.data[next.y * width + next.x];
-        if (local_costmap_.has_value()) {
-          const auto & lm = local_costmap_.value();
-          double wx = 0.0, wy = 0.0;
-          gridToWorld(map, next, wx, wy);
-          GridIndex local_cell;
-          if (worldToGrid(lm, wx, wy, local_cell)) {
-            const int li = local_cell.y * static_cast<int>(lm.info.width) + local_cell.x;
-            if (li >= 0 && li < static_cast<int>(lm.data.size())) {
-              cell_value = std::max(cell_value, lm.data[li]);
-            }
-          }
-        }
-        if (cell_value > 0) {
-          step_cost += settings_.cost_weight * (static_cast<double>(cell_value) / 100.0);
-        }
+      const int8_t cell_value = cellValue(map, next_index, next.x, next.y);
+      if (isBlocked(cell_value)) {
+        continue;
       }
-      const double tentative_g = g_score[current.index] + step_cost;
-      if (tentative_g < g_score[next_index]) {
-        came_from[next_index] = current.index;
-        g_score[next_index] = tentative_g;
-        const double f_score = tentative_g + heuristic(next, goal);
-        open.push(OpenItem{f_score, tentative_g, next_index});
+      double step_cost = (offset.x != 0 && offset.y != 0) ?
+        kDiagonalCost : 1.0;
+      if (settings_.cost_weight > 0.0 && cell_value > 0) {
+        step_cost +=
+          settings_.cost_weight * (static_cast<double>(cell_value) / 100.0);
+      }
+      const double tentative_g = current_g + step_cost;
+      if (visit_gen_[next_index] != generation_ ||
+        tentative_g < g_score_[next_index])
+      {
+        visit_gen_[next_index] = generation_;
+        came_from_[next_index] = current.index;
+        g_score_[next_index] = tentative_g;
+        open_heap_.push_back(
+          OpenItem{tentative_g + heuristic(next, goal), next_index});
+        std::push_heap(
+          open_heap_.begin(), open_heap_.end(),
+          OpenItemGreater{});
       }
     }
   }
@@ -162,9 +206,15 @@ void PathPlanner::reconstructPath(
 
 double PathPlanner::heuristic(const GridIndex & a, const GridIndex & b) const
 {
-  const double dx = static_cast<double>(a.x - b.x);
-  const double dy = static_cast<double>(a.y - b.y);
-  return std::hypot(dx, dy);
+  const double dx = static_cast<double>(std::abs(a.x - b.x));
+  const double dy = static_cast<double>(std::abs(a.y - b.y));
+  if (!settings_.use_diagonal) {
+    // Manhattan distance: tight lower bound for 4-connected moves.
+    return dx + dy;
+  }
+  // Octile distance: tight lower bound for 8-connected moves with
+  // diagonal cost kDiagonalCost.
+  return std::max(dx, dy) + (kDiagonalCost - 1.0) * std::min(dx, dy);
 }
 
 bool PathPlanner::worldToGrid(
@@ -200,47 +250,117 @@ void PathPlanner::gridToWorld(
   wy = origin_y + (static_cast<double>(cell.y) + 0.5) * resolution;
 }
 
-bool PathPlanner::isOccupied(
-  const nav_msgs::msg::OccupancyGrid & map,
-  const GridIndex & cell) const
+void PathPlanner::buildLocalPatch(const nav_msgs::msg::OccupancyGrid & map)
 {
+  patch_active_ = false;
+  if (!local_costmap_.has_value()) {
+    return;
+  }
+  const auto & local = local_costmap_.value();
+
+  // Bounding box of the local costmap on the global grid.
+  const double resolution = map.info.resolution;
+  const double origin_x = map.info.origin.position.x;
+  const double origin_y = map.info.origin.position.y;
+  const double local_x0 = local.info.origin.position.x;
+  const double local_y0 = local.info.origin.position.y;
+  const double local_x1 = local_x0 +
+    static_cast<double>(local.info.width) * local.info.resolution;
+  const double local_y1 = local_y0 +
+    static_cast<double>(local.info.height) * local.info.resolution;
+
   const int width = static_cast<int>(map.info.width);
-  const int index = cell.y * width + cell.x;
-  if (index < 0 || index >= static_cast<int>(map.data.size())) {
-    return true;
-  }
-  const int8_t global_value = map.data.at(index);
-  if (global_value < 0 && !settings_.allow_unknown) {
-    return true;
-  }
-  if (global_value >= settings_.occupied_threshold) {
-    return true;
+  const int height = static_cast<int>(map.info.height);
+  const int x0 = std::max(
+    0, static_cast<int>(std::floor((local_x0 - origin_x) / resolution)));
+  const int y0 = std::max(
+    0, static_cast<int>(std::floor((local_y0 - origin_y) / resolution)));
+  const int x1 = std::min(
+    width - 1,
+    static_cast<int>(std::floor((local_x1 - origin_x) / resolution)));
+  const int y1 = std::min(
+    height - 1,
+    static_cast<int>(std::floor((local_y1 - origin_y) / resolution)));
+  if (x0 > x1 || y0 > y1) {
+    return;
   }
 
-  if (local_costmap_.has_value()) {
-    const auto & local_map = local_costmap_.value();
-    double wx = 0.0;
-    double wy = 0.0;
-    gridToWorld(map, cell, wx, wy);
-    GridIndex local_cell;
-    if (worldToGrid(local_map, wx, wy, local_cell)) {
-      const int local_index =
-        local_cell.y * static_cast<int>(local_map.info.width) + local_cell.x;
-      if (local_index >= 0 &&
-        local_index < static_cast<int>(local_map.data.size()))
-      {
-        const int8_t local_value = local_map.data.at(local_index);
-        if (local_value < 0 && !settings_.allow_unknown) {
-          return true;
-        }
-        if (local_value >= settings_.occupied_threshold) {
-          return true;
+  patch_x0_ = x0;
+  patch_y0_ = y0;
+  patch_x1_ = x1;
+  patch_y1_ = y1;
+  patch_width_ = x1 - x0 + 1;
+  patch_values_.resize(
+    static_cast<size_t>(patch_width_) * static_cast<size_t>(y1 - y0 + 1));
+
+  const int local_width = static_cast<int>(local.info.width);
+  for (int y = y0; y <= y1; ++y) {
+    for (int x = x0; x <= x1; ++x) {
+      const int8_t global_value = map.data[y * width + x];
+      int8_t merged = global_value;
+      double wx = 0.0;
+      double wy = 0.0;
+      gridToWorld(map, GridIndex{x, y}, wx, wy);
+      GridIndex local_cell;
+      if (worldToGrid(local, wx, wy, local_cell)) {
+        const int local_index = local_cell.y * local_width + local_cell.x;
+        if (local_index >= 0 &&
+          local_index < static_cast<int>(local.data.size()))
+        {
+          const int8_t local_value = local.data[local_index];
+          if (!settings_.allow_unknown &&
+            (global_value < 0 || local_value < 0))
+          {
+            // Unknown in either grid blocks the cell; keep it marked
+            // unknown so isBlocked() rejects it.
+            merged = -1;
+          } else {
+            merged = std::max(global_value, local_value);
+          }
         }
       }
+      patch_values_[(y - y0) * patch_width_ + (x - x0)] = merged;
     }
   }
+  patch_active_ = true;
+}
 
-  return false;
+int8_t PathPlanner::cellValue(
+  const nav_msgs::msg::OccupancyGrid & map, int index, int x, int y) const
+{
+  if (patch_active_ && x >= patch_x0_ && x <= patch_x1_ && y >= patch_y0_ &&
+    y <= patch_y1_)
+  {
+    return patch_values_[(y - patch_y0_) * patch_width_ + (x - patch_x0_)];
+  }
+  return map.data[index];
+}
+
+bool PathPlanner::isBlocked(int8_t value) const
+{
+  if (value < 0) {
+    return !settings_.allow_unknown;
+  }
+  return value >= settings_.occupied_threshold;
+}
+
+void PathPlanner::beginSearchEpoch(int map_size)
+{
+  if (static_cast<int>(visit_gen_.size()) != map_size) {
+    g_score_.assign(map_size, std::numeric_limits<double>::infinity());
+    came_from_.assign(map_size, -1);
+    visit_gen_.assign(map_size, 0);
+    closed_gen_.assign(map_size, 0);
+    generation_ = 0;
+  }
+  ++generation_;
+  if (generation_ == 0) {
+    // The 32-bit stamp wrapped: old stamps would alias the new epoch,
+    // so reset them once.
+    std::fill(visit_gen_.begin(), visit_gen_.end(), 0);
+    std::fill(closed_gen_.begin(), closed_gen_.end(), 0);
+    generation_ = 1;
+  }
 }
 
 }  // namespace path_planner

--- a/core_path_planner/src/path_planner_node.cpp
+++ b/core_path_planner/src/path_planner_node.cpp
@@ -1,5 +1,7 @@
 #include "path_planner/path_planner_node.hpp"
 
+#include <chrono>
+
 namespace path_planner
 {
 
@@ -24,6 +26,13 @@ PathPlannerNode::PathPlannerNode(const rclcpp::NodeOptions & options)
   allow_unknown_ = declare_parameter<bool>("allow_unknown", true);
   use_diagonal_ = declare_parameter<bool>("use_diagonal", true);
   cost_weight_ = declare_parameter<double>("cost_weight", 0.0);
+  search_window_margin_ =
+    declare_parameter<int>("search_window_margin", -1);
+  replan_rate_hz_ = declare_parameter<double>("replan_rate_hz", 5.0);
+  replan_position_tolerance_ =
+    declare_parameter<double>("replan_position_tolerance", 0.0);
+  replan_yaw_tolerance_ =
+    declare_parameter<double>("replan_yaw_tolerance", 0.0);
 
   global_map_sub_ = create_subscription<nav_msgs::msg::OccupancyGrid>(
     global_map_topic_, rclcpp::QoS(1).transient_local().reliable(),
@@ -54,7 +63,16 @@ PathPlannerNode::PathPlannerNode(const rclcpp::NodeOptions & options)
 
   planner_.setSettings(
     PathPlanner::Settings{occupied_threshold_,
-      allow_unknown_, use_diagonal_, cost_weight_});
+      allow_unknown_, use_diagonal_, cost_weight_, search_window_margin_});
+
+  if (replan_rate_hz_ <= 0.0) {
+    RCLCPP_WARN(
+      get_logger(), "replan_rate_hz must be positive; falling back to 5.0");
+    replan_rate_hz_ = 5.0;
+  }
+  replan_timer_ = create_wall_timer(
+    std::chrono::duration<double>(1.0 / replan_rate_hz_),
+    std::bind(&PathPlannerNode::onReplanTimer, this));
 
   RCLCPP_INFO(get_logger(), "Path Planner Node initialized");
 }
@@ -69,7 +87,7 @@ void PathPlannerNode::onGlobalMapReceived(
       get_logger(), "Global map received: %ux%u, res=%.3f",
       msg->info.width, msg->info.height, msg->info.resolution);
   }
-  // tryPlan();
+  plan_pending_ = true;
 }
 
 void PathPlannerNode::onLocalCostmapReceived(
@@ -77,15 +95,24 @@ void PathPlannerNode::onLocalCostmapReceived(
 {
   planner_.setLocalCostmap(*msg);
   RCLCPP_DEBUG(get_logger(), "Local costmap received");
-  tryPlan();
+  plan_pending_ = true;
 }
 
 void PathPlannerNode::onStartPoseReceived(
   const geometry_msgs::msg::PoseStamped::SharedPtr msg)
 {
+  if (startPoseChanged(*msg)) {
+    plan_pending_ = true;
+  }
   start_pose_ = *msg;
   RCLCPP_DEBUG(get_logger(), "Start pose received");
-  tryPlan();
+
+  // Keep downstream consumers fed between replans: re-transform the last
+  // path with the fresh pose (matters in local-frame mode, where the path
+  // is expressed relative to the robot pose at publish time).
+  if (!last_path_cells_.empty() && global_map_.has_value()) {
+    publishPath(last_path_cells_);
+  }
 }
 
 void PathPlannerNode::onGoalPoseReceived(
@@ -93,7 +120,42 @@ void PathPlannerNode::onGoalPoseReceived(
 {
   goal_pose_ = *msg;
   RCLCPP_INFO(get_logger(), "Goal pose received");
-  // tryPlan();
+  plan_pending_ = true;
+}
+
+void PathPlannerNode::onReplanTimer()
+{
+  if (!plan_pending_) {
+    return;
+  }
+  if (!global_map_.has_value() || !start_pose_.has_value() ||
+    !goal_pose_.has_value())
+  {
+    // Keep the request pending until all inputs are available.
+    return;
+  }
+  plan_pending_ = false;
+  tryPlan();
+}
+
+bool PathPlannerNode::startPoseChanged(
+  const geometry_msgs::msg::PoseStamped & pose) const
+{
+  if (!last_planned_start_.has_value()) {
+    return true;
+  }
+  const auto & last = last_planned_start_->pose;
+  const double dx = pose.pose.position.x - last.position.x;
+  const double dy = pose.pose.position.y - last.position.y;
+  if (std::hypot(dx, dy) > replan_position_tolerance_) {
+    return true;
+  }
+  const double yaw_delta = std::abs(
+    std::remainder(
+      getYawFromQuaternion(pose.pose.orientation) -
+      getYawFromQuaternion(last.orientation),
+      2.0 * M_PI));
+  return yaw_delta > replan_yaw_tolerance_;
 }
 
 void PathPlannerNode::tryPlan()
@@ -140,7 +202,11 @@ void PathPlannerNode::tryPlan()
         result.path.size(),
         start_pose_->pose.position.x, start_pose_->pose.position.y,
         goal_pose_->pose.position.x, goal_pose_->pose.position.y);
-      publishPath(result.path);
+      // Record the planned-from pose only on success so failed plans are
+      // retried as soon as any input event arrives.
+      last_planned_start_ = start_pose_;
+      last_path_cells_ = result.path;
+      publishPath(last_path_cells_);
       break;
   }
 }
@@ -157,6 +223,11 @@ void PathPlannerNode::publishPath(
   const auto & map = *global_map_;
   const auto & robot_pose = start_pose_->pose;
 
+  // Hoist the global->local rotation out of the per-pose loop.
+  const double yaw = getYawFromQuaternion(robot_pose.orientation);
+  const double cos_yaw = std::cos(-yaw);
+  const double sin_yaw = std::sin(-yaw);
+
   for (const auto & cell : path_cells) {
     double global_x = 0.0;
     double global_y = 0.0;
@@ -169,11 +240,10 @@ void PathPlannerNode::publishPath(
       pose.pose.position.x = global_x;
       pose.pose.position.y = global_y;
     } else {
-      double local_x = 0.0;
-      double local_y = 0.0;
-      transformToLocal(global_x, global_y, robot_pose, local_x, local_y);
-      pose.pose.position.x = local_x;
-      pose.pose.position.y = local_y;
+      const double dx = global_x - robot_pose.position.x;
+      const double dy = global_y - robot_pose.position.y;
+      pose.pose.position.x = dx * cos_yaw - dy * sin_yaw;
+      pose.pose.position.y = dx * sin_yaw + dy * cos_yaw;
     }
 
     pose.pose.position.z = 0.0;
@@ -182,25 +252,6 @@ void PathPlannerNode::publishPath(
   }
 
   path_pub_->publish(path_msg);
-}
-
-void PathPlannerNode::transformToLocal(
-  double global_x, double global_y,
-  const geometry_msgs::msg::Pose & robot_pose, double & local_x,
-  double & local_y) const
-{
-  // Translate to robot origin
-  const double dx = global_x - robot_pose.position.x;
-  const double dy = global_y - robot_pose.position.y;
-
-  // Get robot yaw and rotate by negative yaw
-  const double yaw = getYawFromQuaternion(robot_pose.orientation);
-  const double cos_yaw = std::cos(-yaw);
-  const double sin_yaw = std::sin(-yaw);
-
-  // Apply rotation to get local coordinates
-  local_x = dx * cos_yaw - dy * sin_yaw;
-  local_y = dx * sin_yaw + dy * cos_yaw;
 }
 
 double PathPlannerNode::getYawFromQuaternion(


### PR DESCRIPTION
実測プロファイリングに基づく修正:
- ヒューリスティックをユークリッドからオクタイル/マンハッタン距離に変更 (8近傍で展開ノード数-46%、探索時間-59%。経路コストは不変)
- ローカルコストマップを計画開始時に1回だけグローバルグリッドへ合成 (従来は近傍セルごとに座標変換を最大2回実行、+18%のオーバーヘッド)
- 近傍ループのチェック順を bounds→closed→占有 の安い順に変更
- スクラッチバッファ(g_score/came_from/closed)を世代スタンプで再利用し 毎プランのO(マップセル数)確保・初期化を排除
- openリストをメンバvector+push_heap/pop_heapで再利用、未使用のgフィールド削除
- 再計画をトピック受信ごとの無条件実行からタイマー駆動(replan_rate_hz)+ 入力変化ゲートに変更 (従来はローカルコストマップ/スタート姿勢の受信毎に グローバルマップ全域のA*を実行)
- スタート姿勢受信時は保存済みパスを最新姿勢で再変換して再パブリッシュ (ローカル座標系の下流互換性を維持、A*は走らない)
- オプションのウィンドウ探索(search_window_margin、デフォルト無効)を追加
- goal/map受信時に再計画されないバグを修正 (tryPlanがコメントアウトされていた)

新旧比較ベンチマーク11シナリオで経路コスト・ステータスの完全一致を確認済み。
1000x1000マップ: 56.2ms→16.5ms、ローカルコストマップ+cost_weight=2.0: 60.6ms→17.1ms、 4近傍500x500: 11.4ms→1.0ms。