### PR TITLE
砲塔ヨー推定のdt修正と起動時ジャイロバイアス較正

### DIFF
--- a/core_body_controller/src/target_angle_node.cpp
+++ b/core_body_controller/src/target_angle_node.cpp
@@ -58,8 +58,14 @@ private:
   constexpr static double MAX_ROTATE_ACCELERATION = M_PI * 3;
   constexpr static std::chrono::milliseconds TIMER_PERIOD = std::chrono::milliseconds(10);
   constexpr static double TIMER_DT = std::chrono::duration<double>(TIMER_PERIOD).count();
+  // IMU integration: sample gaps longer than this are treated as dropouts (not integrated).
+  // Must stay above the slowest expected IMU period (real Mid-360: 5ms, Unity sim: ~59ms).
+  constexpr static double MAX_IMU_DT = 0.1;
+  constexpr static double CALIB_DURATION = 2.0;
+  constexpr static double CALIB_GATE_STD = 0.01;  // rad/s; above this the robot is moving
 
-  PID pid_ = PID(2.0, 0.0, 0.00, TIMER_DT, MAX_ROTATION, MAX_ROTATE_ACCELERATION);
+  // kp=4.0 keeps the effective stiffness the old code had while its yaw estimate ran at 2x scale
+  PID pid_ = PID(4.0, 0.0, 0.00, TIMER_DT, MAX_ROTATION, MAX_ROTATE_ACCELERATION);
   double gimbalControl();
 
   rclcpp::TimerBase::SharedPtr timer_;
@@ -71,6 +77,14 @@ private:
   bool node_initialized_ = false;
   bool rotation_flag_ = false;
   geometry_msgs::msg::Twist latest_twist_;
+  rclcpp::Time last_imu_stamp_{0, 0, RCL_ROS_TIME};
+  rclcpp::Time calib_start_{0, 0, RCL_ROS_TIME};
+  double gyro_bias_z_ = 0.0;
+  double calib_sum_ = 0.0;
+  double calib_sum_sq_ = 0.0;
+  int calib_count_ = 0;
+  bool calibration_done_ = false;
+  rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr world_angle_pub_;
 
   static double normalizeAngle(double angle) {
     return std::atan2(std::sin(angle), std::cos(angle));
@@ -93,13 +107,41 @@ TargetAngleNode::TargetAngleNode() : Node("target_angle_node") {
   //     });
   imu_sub_ = this->create_subscription<sensor_msgs::msg::Imu>(
       "imu", 10, [this](const sensor_msgs::msg::Imu::SharedPtr msg) {
-        node_initialized_ = true;
-        // quaternion to euler
-        // latest_world_angle_ = std::atan2(2.0 * (msg->orientation.w * msg->orientation.z + msg->orientation.x * msg->orientation.y),
-        //                               1.0 - 2.0 * (msg->orientation.y * msg->orientation.y + msg->orientation.z * msg->orientation.z));
-
-        // only use yaw omega
-        latest_world_angle_ = normalizeAngle(latest_world_angle_ - msg->angular_velocity.z * TIMER_DT + M_PI * 0.0001);
+        const rclcpp::Time stamp(msg->header.stamp, RCL_ROS_TIME);
+        if (!calibration_done_) {
+          // measure gyro z bias while stationary at startup; reject if the robot is moving
+          if (calib_start_.nanoseconds() == 0) {
+            calib_start_ = stamp;
+          }
+          calib_sum_ += msg->angular_velocity.z;
+          calib_sum_sq_ += msg->angular_velocity.z * msg->angular_velocity.z;
+          calib_count_++;
+          if ((stamp - calib_start_).seconds() >= CALIB_DURATION) {
+            const double mean = calib_sum_ / calib_count_;
+            const double var = calib_sum_sq_ / calib_count_ - mean * mean;
+            const double stddev = std::sqrt(var > 0.0 ? var : 0.0);
+            if (stddev < CALIB_GATE_STD) {
+              gyro_bias_z_ = mean;
+              RCLCPP_INFO(this->get_logger(),
+                          "gyro bias calibrated: %+.5f rad/s (std %.5f, %d samples)",
+                          gyro_bias_z_, stddev, calib_count_);
+            } else {
+              RCLCPP_WARN(this->get_logger(),
+                          "gyro bias calibration rejected (std %.5f rad/s, robot moving?): using 0",
+                          stddev);
+            }
+            calibration_done_ = true;
+            node_initialized_ = true;
+          }
+        } else {
+          const double dt = (stamp - last_imu_stamp_).seconds();
+          // dt<=0: duplicate/backwards stamp, dt>MAX_IMU_DT: dropout gap -- skip both
+          if (dt > 0.0 && dt <= MAX_IMU_DT) {
+            latest_world_angle_ = normalizeAngle(
+                latest_world_angle_ - (msg->angular_velocity.z - gyro_bias_z_) * dt);
+          }
+        }
+        last_imu_stamp_ = stamp;
       });
   world_target_angle_sub_ = this->create_subscription<std_msgs::msg::Float64>(
       "yaw_target_angle", 10, [this](const std_msgs::msg::Float64::SharedPtr msg) {
@@ -114,6 +156,7 @@ TargetAngleNode::TargetAngleNode() : Node("target_angle_node") {
         emergency_stop_flag_ = msg->data;
       });
   target_omega_pub_ = this->create_publisher<std_msgs::msg::Float64>("target_omega", 10);
+  world_angle_pub_ = this->create_publisher<std_msgs::msg::Float64>("turret/world_angle", 10);
 }
 
 double TargetAngleNode::gimbalControl() {
@@ -135,6 +178,10 @@ void TargetAngleNode::timer_callback() {
     RCLCPP_WARN(this->get_logger(), "Waiting for IMU data...");
     return;
   }
+
+  std_msgs::msg::Float64 world_angle_msg;
+  world_angle_msg.data = latest_world_angle_;
+  world_angle_pub_->publish(world_angle_msg);
 
   core_msgs::msg::CANArray can_msg;
   can_msg.array.resize(1);


### PR DESCRIPTION
- IMU積分をheader.stamp差分に変更。200HzのIMUを固定10msで積分して ヨー推定が実回転の2倍で進むバグの修正（ガード 0<dt<=0.1s）
- ハードコードのドリフト補正定数 +pi*1e-4 を撤去し、起動時2秒の 静止バイアス較正に置換（分散ゲート付き、棄却時はbias=0+WARNで続行）
- kp 2->4（旧コードは2倍スケールの誤差に対し実効ゲイン4で動作して いたため、実効剛性を維持）
- 検証用トピック turret/world_angle を追加

検証: 実走行bag再生で参照実装と一致（誤差0.000度）、FAST-LIO併録bag
との比較でスケール0.989・残留ドリフト-0.19度/min（旧コードはスケール2.0）