### PR TITLE
Simplify CI failure handling and launch setup

### DIFF
--- a/.github/workflows/ros2_ci.yml
+++ b/.github/workflows/ros2_ci.yml
@@ -50,23 +50,12 @@ jobs:
         run: apt-get install -y ros-${{ matrix.rosdistro }}-ament-clang-format clang-format
 
       - name: Build tests
-        id: build_test
         run: |
           . /opt/ros/${{ matrix.rosdistro }}/setup.sh &&
           cd /ros2_ws &&
           colcon build
-        continue-on-error: true
-
-      - name: build_test command success
-        if: steps.build_test.outcome == 'success'
-        run: echo "result - success"
-
-      - name: build_test command failure
-        if: steps.build_test.outcome == 'failure'
-        run: echo "result - failure" && exit 1
 
       - name: Run tests
-        id: run_test
         run: |
           . /opt/ros/${{ matrix.rosdistro }}/setup.sh &&
           cd /ros2_ws &&
@@ -84,32 +73,6 @@ jobs:
             core_tools \
             ros_tcp_endpoint &&
           colcon test-result --verbose
-        continue-on-error: true
-
-      - name: Run core_test package
-        id: run_core_test
-        run: |
-          . /opt/ros/${{ matrix.rosdistro }}/setup.sh &&
-          cd /ros2_ws &&
-          colcon test --packages-select core_test &&
-          colcon test-result --verbose
-        continue-on-error: true
-
-      - name: run_test command success
-        if: steps.run_test.outcome == 'success'
-        run: echo "result - success"
-
-      - name: run_test command failure
-        if: steps.run_test.outcome == 'failure'
-        run: echo "result - failure" && exit 1
-
-      - name: run_core_test command success
-        if: steps.run_core_test.outcome == 'success'
-        run: echo "result - success"
-
-      - name: run_core_test command failure
-        if: steps.run_core_test.outcome == 'failure'
-        run: echo "result - failure" && exit 1
 
       - name: Format with ament_clang_format
         if: github.event_name == 'push' && github.ref_name != 'main'

--- a/core_launch/launch/navigation.launch.py
+++ b/core_launch/launch/navigation.launch.py
@@ -44,18 +44,12 @@ def _launch_nodes(context):
     """Resolve map preset and return all node actions."""
     # ── Resolve launch arguments ─────────────────────────────────────
     env = context.launch_configurations['environment']
-    odom_src = context.launch_configurations['odom_source']
     map_name = context.launch_configurations['map_name']
-    init_yaw = context.launch_configurations['init_yaw']
     use_rviz = context.launch_configurations['use_rviz']
     use_localization = context.launch_configurations.get(
         'use_localization', 'false').lower() == 'true'
 
     is_real = (env == 'real')
-    use_fastlio = is_real or (odom_src == 'fastlio')
-    effective_odom_source = 'fastlio' if is_real else odom_src
-    imu_topic = '/livox/imu' if is_real else '/imu'
-    lidar_type = 4 if is_real else 0
 
     # ── Map preset ───────────────────────────────────────────────────
     preset = MAP_PRESETS.get(map_name)
@@ -65,16 +59,11 @@ def _launch_nodes(context):
             f"Unknown map_name '{map_name}'. Available: {available}")
 
     core_launch_share = get_package_share_directory('core_launch')
-    map_image_path = os.path.join(core_launch_share, 'maps', preset['image'])
 
     # ── Package directories ──────────────────────────────────────────
-    mppi_share = get_package_share_directory('core_mppi')
-    costmap_share = get_package_share_directory('core_costmap_builder')
     body_ctrl_share = get_package_share_directory('core_body_controller')
 
     rviz_config = os.path.join(core_launch_share, 'config', 'navigation.rviz')
-    mppi_params = os.path.join(mppi_share, 'param', 'default_params.yaml')
-    costmap_params = os.path.join(costmap_share, 'config', 'costmap_build_node.yaml')
 
     livox_user_config = PathJoinSubstitution([
         FindPackageShare('livox_ros_driver2'), 'config', 'MID360_config.json',


### PR DESCRIPTION
## Summary

- Let the ROS 2 build and test steps report failures directly.
- Remove redundant status-reporting steps and the duplicate `core_test` execution.
- Remove unused navigation launch variables and package path lookups.

## Why

The workflow contained unnecessary `continue-on-error` bookkeeping and ran `core_test` twice. The navigation launch file also initialized values that are unused by the active launch actions.

## Impact

CI failures are reported at the failing build or test step, while `core_test` remains covered by the combined package test command. Active navigation launch behavior is unchanged.

## Validation

- Parsed `navigation.launch.py` with Python's AST parser.
- Parsed `ros2_ci.yml` as YAML.
- Ran `git diff --cached --check` before committing.
